### PR TITLE
Count matcher opcodes and set as MATCHER_OPCODES_COUNT

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -270,7 +270,8 @@ endif
 CXXFLAGS          ?= -O3 -funroll-loops -fPIC -D_FORTIFY_SOURCE=2
 override CXXFLAGS += -Wall -g -I ./include/ \
                      -DVERSION=\"$(VERSION)\" -Wno-variadic-macros \
-                     -DLLVM_MINOR=$(LLVM_MINOR) -DLLVM_MAJOR=$(LLVM_MAJOR)
+                     -DLLVM_MINOR=$(LLVM_MINOR) -DLLVM_MAJOR=$(LLVM_MAJOR) \
+                     -DMATCHER_OPCODES_COUNT=$(shell grep -c 'GI[R|M].*_.*,' $(FUZZING_HOME)/$(LLVM)/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelector.h)
 
 ifneq "$(shell $(LLVM_CONFIG) --includedir) 2> /dev/null" ""
   CLANG_CFL  = -I$(shell $(LLVM_CONFIG) --includedir)

--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -1184,11 +1184,14 @@ size_t AFLCoverage::instrumentGlobalIsel(Module &M) {
       SwitchInst *Switch = dyn_cast<SwitchInst>(Terminator);
 
       // Check `InstructionSelector.h` for Opcode details.
-      /// TODO: This number needs to be updated according to the LLVM
-      /// version you ARE compiling, not the compiler's version. However,
-      /// it's too late to retrive enum number at IR stage, so has to be
-      /// manual.
-      if (!Switch || Switch->getNumCases() != 66) { continue; }
+#if !defined(MATCHER_OPCODES_COUNT)
+  #error "MATCHER_OPCODES_COUNT should be defined"
+#else
+  #define XSTR(x) STR(x)
+  #define STR(x) #x
+  #pragma message "The value of MATCHER_OPCODES_COUNT: "  XSTR(MATCHER_OPCODES_COUNT)
+#endif
+      if (!Switch || Switch->getNumCases() != MATCHER_OPCODES_COUNT) { continue; }
 
       // Condition is one of the Opcode that is taken out of the
       // MatchTable.


### PR DESCRIPTION
The changes enable automatically counting the number of matcher opcodes and saves the value in `MATCHER_OPCODES_COUNT` macro at build time, so that it no longer requires code changes for updating the number in the future. @DataCorrupted Instructed me using regex to match all the opcodes we want to count in the InstructionSelector.h

I referred to the following resources:
* Pass macro definition from "make" command line arguments (-D) to c++ source code: (https://stackoverflow.com/questions/9052792/how-to-pass-macro-definition-from-make-command-line-arguments-d-to-c-source/53527858#53527858)
* Print the value of a #define at compile-time (https://stackoverflow.com/questions/1562074/how-do-i-show-the-value-of-a-define-at-compile-time)

I have tested the changes by rerun build.sh and fuzz.py after rebuild.

